### PR TITLE
fix: fixxed homebrew pipeline

### DIFF
--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -89,19 +89,23 @@ jobs:
 
       - name: Create New Branch
         run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          BRANCH_NAME="action/updates-for-pr/$VERSION"
           cd tap_repo
-          git checkout -b "action/updates-for-pr"
-          # git pull origin action/updates-for-pr
+          git checkout -b "BRANCH_NAME"
+          # git pull origin BRANCH_NAME
 
       - name: Copy Data to Homebrew Tap Repo
         run: |
+          VERSION=$(git describe --tags --abbrev=0)
+
           cd tap_repo
           
           # Ensures the Formula directory exists; create if it doesn't
           mkdir -p Formula
 
           # Copy the generated formula to the tap repository
-          cp ../$SOFTWARE_NAME.rb ./Formula/$SOFTWARE_NAME.rb            
+          cp ../${{ vars.SOFTWARE_NAME }}.rb ./Formula/${{ vars.SOFTWARE_NAME }}.rb            
 
           # Commit 
           git add -A
@@ -109,10 +113,13 @@ jobs:
           
       - name: Push Changes to Homebrew Tap Repo
         run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          BRANCH_NAME="action/updates-for-pr/$VERSION"
+          echo "Branch Name: $BRANCH_NAME"
           cd tap_repo
-          git push --set-upstream origin action/updates-for-pr
+          git push --set-upstream origin $BRANCH_NAME
       
-      - name: Create Pull Request
-        run: |
-          PR_DATA=$(jq -n --arg title "Add/update formula for version '$VERSION'" --arg head "action/updates-for-pr" --arg base "main" --arg body "This PR includes updates for $SOFTWARE_NAME/$VERSION" '{title: $title, head: $head, base: $base, body: $body}')
-          curl -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/migration-demo-wd/homebrew-tap/pulls -d "$PR_DATA"
+      # - name: Create Pull Request
+      #   run: |
+      #     PR_DATA=$(jq -n --arg title "Add/update formula for version '$VERSION'" --arg head "action/updates-for-pr" --arg base "main" --arg body "This PR includes updates for $SOFTWARE_NAME/$VERSION" '{title: $title, head: $head, base: $base, body: $body}')
+      #     curl -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/migration-demo-wd/homebrew-tap/pulls -d "$PR_DATA"


### PR DESCRIPTION
Changed Homebrew pipeline, so the software name isn't hardcoded anymore. 
Deleted/Commented out last part of the pipeline which was responsible for creating a PR in the Homebrew Tap repo (But it nerver worked)